### PR TITLE
adds exception checking for user input boundary

### DIFF
--- a/src/CommandLineEntryPoint.java
+++ b/src/CommandLineEntryPoint.java
@@ -35,10 +35,15 @@ public class CommandLineEntryPoint implements UserRequestProvider<String[]>{
 		if(response == null) {
 			System.err.println("Error: Engine responded with null");
 		}
+		if (response instanceof EngineResponseException engineResponseException) {
+			Exception e = engineResponseException.getException();
+			System.err.println("Error: encountered exception " + e + ", ignoring...");
+		}
 		if (response.getResponseCode().isFailure()){
 			System.out.println("Failed :^(");
 		} else {
 			System.out.println("Successful! Output written at: " + args[1]);
 		}
+		System.exit(0);
 	}
 }

--- a/src/ComputeEngineImplementation.java
+++ b/src/ComputeEngineImplementation.java
@@ -25,17 +25,25 @@ public class ComputeEngineImplementation implements ComputeEngine {
 
   @Override
   public EngineResponse submitRequest(UserRequest userRequest) {
+	try {
+		return submitRequestHelper(userRequest);
+	} catch (Exception e) {
+		return new EngineResponseExceptionImplementation(e);
+	}
+  }
+  
+  public EngineResponse submitRequestHelper(UserRequest userRequest) throws Exception {
 	if(userRequest == null) {
 		throw new IllegalArgumentException("UserRequest cannot be null");
 	}
-    EngineResponse engineResponse = sendStreamForFactorial(userRequest.getRequestStream());
-    NumStream resultStream = engineResponse.getRequestResult().getResultNumStream();
+	EngineResponse engineResponse = sendStreamForFactorial(userRequest.getRequestStream());
+	NumStream resultStream = engineResponse.getRequestResult().getResultNumStream();
 
-    RequestResult requestResult = engineResponse.getRequestResult();
+	RequestResult requestResult = engineResponse.getRequestResult();
 
-    requestResult.setResultString(processResultString(userRequest, (ArrayList<Integer>) resultStream.getIntegers()));
+	requestResult.setResultString(processResultString(userRequest, (ArrayList<Integer>) resultStream.getIntegers()));
 
-    return engineResponse;
+	return engineResponse;
   }
 
   @Override

--- a/src/EngineResponseException.java
+++ b/src/EngineResponseException.java
@@ -1,0 +1,15 @@
+
+public class EngineResponseException extends ConcreteEngineResponse{
+
+	private Exception exception;
+
+	public EngineResponseException(Exception exception) {
+		super(ResponseCode.FAILED);
+		this.exception = exception;
+	}
+	
+	public Exception getException() {
+		return this.exception;
+	}
+
+}

--- a/src/EngineResponseException.java
+++ b/src/EngineResponseException.java
@@ -1,15 +1,8 @@
 
-public class EngineResponseException extends ConcreteEngineResponse{
+public interface EngineResponseException extends EngineResponse{
 
-	private Exception exception;
-
-	public EngineResponseException(Exception exception) {
-		super(ResponseCode.FAILED);
-		this.exception = exception;
-	}
+	public Exception getException();
 	
-	public Exception getException() {
-		return this.exception;
-	}
+	public void setException(Exception exception);
 
 }

--- a/src/EngineResponseExceptionImplementation.java
+++ b/src/EngineResponseExceptionImplementation.java
@@ -1,0 +1,43 @@
+
+public class EngineResponseExceptionImplementation implements EngineResponseException{
+	
+	private Exception exception;
+	private ResponseCode responseCode = ResponseCode.FAILED;
+	private RequestResult requestResult;
+
+	public EngineResponseExceptionImplementation (Exception exception) { 
+		this.exception = exception;
+	}
+
+	@Override
+	public ResponseCode getResponseCode() {
+
+		return this.responseCode;
+	}
+
+	@Override
+	public RequestResult getRequestResult() {
+		return this.requestResult;
+	}
+
+	@Override
+	public void setResponseCode(ResponseCode responseCode) {
+		this.responseCode = responseCode;
+	}
+
+	@Override
+	public void setRequestResult(RequestResult requestResult) {
+		this.requestResult = requestResult;
+	}
+
+	@Override
+	public Exception getException() {
+		return this.exception;
+	}
+
+	@Override
+	public void setException(Exception exception) {
+		this.exception = exception;
+	}
+
+}

--- a/src/EngineResponseExceptionImplementation.java
+++ b/src/EngineResponseExceptionImplementation.java
@@ -5,7 +5,7 @@ public class EngineResponseExceptionImplementation implements EngineResponseExce
 	private ResponseCode responseCode = ResponseCode.FAILED;
 	private RequestResult requestResult;
 
-	public EngineResponseExceptionImplementation (Exception exception) { 
+	public EngineResponseExceptionImplementation(Exception exception) { 
 		this.exception = exception;
 	}
 

--- a/src/Mediator.java
+++ b/src/Mediator.java
@@ -40,6 +40,15 @@ public class Mediator {
 		if(provider == null) {
 			throw new IllegalArgumentException("UserRequestProvider cannot be null");
 		}
+		try {
+			provider.propigateResponse(sendInputHelper(provider));
+		} catch (Exception e) {
+			provider.propigateResponse(new EngineResponseException(e));
+		}
+
+	}
+	
+	private <T> EngineResponse sendInputHelper(UserRequestProvider<T> provider) throws Exception {
 		UserRequest userRequest = provider.generateRequest(provider.getInput());
 
 		EngineResponse response = new ConcreteEngineResponse(ResponseCode.FAILED);
@@ -66,7 +75,7 @@ public class Mediator {
 			}
 		}
 
-		provider.propigateResponse(response);
+		return response;
 	}
 
 	private Optional<InputRequest> generateInputRequest(UserRequest request) {

--- a/src/Mediator.java
+++ b/src/Mediator.java
@@ -43,7 +43,7 @@ public class Mediator {
 		try {
 			provider.propigateResponse(sendInputHelper(provider));
 		} catch (Exception e) {
-			provider.propigateResponse(new EngineResponseException(e));
+			provider.propigateResponse(new EngineResponseExceptionImplementation(e));
 		}
 
 	}


### PR DESCRIPTION
Stops exceptions from propagating between network/process boundaries by wrapping them in a EngineResponseException object, allowing UserRequestProvider to deal with them like a regular EngineResponse, or to optionally handle the exception.