### PR TITLE
Multithreads coordinator calls to computation component

### DIFF
--- a/src/MultiThreadedMediator.java
+++ b/src/MultiThreadedMediator.java
@@ -1,0 +1,21 @@
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import datastoreapi.DataStoreAPI;
+
+public class MultiThreadedMediator extends Mediator{
+
+    private ExecutorService executorService = Executors.newFixedThreadPool(10);
+
+    public MultiThreadedMediator(DataStoreAPI dataStoreApi, ComputeEngine computeEngine) {
+        super(dataStoreApi, computeEngine);
+    }
+
+    @Override
+    public <T> void sendInput(UserRequestProvider<T> provider) {
+        executorService.submit(() -> {
+            super.sendInput(provider);
+        });
+    }
+
+}

--- a/src/MultiThreadedUserIOApi.java
+++ b/src/MultiThreadedUserIOApi.java
@@ -1,0 +1,19 @@
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+public class MultiThreadedUserIOApi extends UserIOApi{
+
+    private ExecutorService executorService = Executors.newFixedThreadPool(10);
+
+    public MultiThreadedUserIOApi(ComputeEngine computeEngine) {
+        super(computeEngine);
+    }
+
+    public Future<EngineResponse> submitRequest(UserRequest request) {
+        return executorService.submit(() -> {
+            return sendRequest(request);
+        });
+    }
+
+}

--- a/src/MultiThreadedUserIOApi.java
+++ b/src/MultiThreadedUserIOApi.java
@@ -12,7 +12,7 @@ public class MultiThreadedUserIOApi extends UserIOApi{
 
     public Future<EngineResponse> submitRequest(UserRequest request) {
         return executorService.submit(() -> {
-            return sendRequest(request);
+            return super.sendRequest(request);
         });
     }
 


### PR DESCRIPTION
I wasn't sure if the coordinator component part 2 was referring to the "coordinator" field in TestUser and TestMultiUser (`UserIOApi`) or the coordinator component we made in assignment 4 (`Mediator`) so I just made a multi-threaded type for both of them.
`MultiThreadedUserIOApi` submits requests using the new `submitRequest` function and returns a `Future<EngineResponse>`.
`MultiThreadedMediator` just overrides the default `sendInput` function, which returns void.