### PR TITLE
Adds BigInteger support

### DIFF
--- a/src/BigIntegerNumStreamImplementation.java
+++ b/src/BigIntegerNumStreamImplementation.java
@@ -1,0 +1,33 @@
+import java.math.BigInteger;
+import java.util.List;
+
+import interfaces.BigIntegerNumStream;
+
+public class BigIntegerNumStreamImplementation implements BigIntegerNumStream{
+
+    List<BigInteger> bigIntList;
+
+    public BigIntegerNumStreamImplementation(List<BigInteger> bigIntList) {
+        this.bigIntList = bigIntList;
+    }
+    @Override
+    public List<Integer> getIntegers() {
+        throw new UnsupportedOperationException("Unimplemented method 'getIntegers'");
+    }
+
+    @Override
+    public void setIntegerList(List<Integer> integerList) {
+        throw new UnsupportedOperationException("Unimplemented method 'setIntegerList'");
+    }
+
+    @Override
+    public List<BigInteger> getBigIntegers() {
+        return bigIntList;
+    }
+
+    @Override
+    public void setBigIntegerList(List<BigInteger> bigIntegerList) {
+        this.bigIntList = bigIntegerList;
+    }
+    
+}

--- a/src/CommandLineEntryPoint.java
+++ b/src/CommandLineEntryPoint.java
@@ -37,7 +37,7 @@ public class CommandLineEntryPoint implements UserRequestProvider<String[]>{
 		}
 		if (response instanceof EngineResponseException engineResponseException) {
 			Exception e = engineResponseException.getException();
-			System.err.println("Error: encountered exception " + e + ", ignoring...");
+			e.printStackTrace();
 		}
 		if (response.getResponseCode().isFailure()){
 			System.out.println("Failed :^(");

--- a/src/ComputationImplementation.java
+++ b/src/ComputationImplementation.java
@@ -14,38 +14,16 @@ public class ComputationImplementation implements ComputeEngineComputation {
         if (numStream instanceof BigIntegerNumStream biNumStream){
             ArrayList<BigInteger> resultList = new ArrayList<>();
             factorialSumLoopForBigIntegers(biNumStream.getBigIntegers(), resultList);
-            NumStream resultStream = new BigIntegerNumStream() {
-
-                @Override
-                public List<Integer> getIntegers() {
-                    throw new UnsupportedOperationException("Unimplemented method 'getIntegers'");
-                }
-
-                @Override
-                public void setIntegerList(List<Integer> integerList) {
-                    throw new UnsupportedOperationException("Unimplemented method 'setIntegerList'");
-                }
-
-                @Override
-                public List<BigInteger> getBigIntegers() {
-                    return resultList;
-                }
-
-                @Override
-                public void setBigIntegerList(List<BigInteger> bigIntegerList) {
-                    throw new UnsupportedOperationException("Unimplemented method 'setBigIntegerList'");
-                }
-
-            };
+            NumStream resultStream = new BigIntegerNumStreamImplementation(resultList);
             RequestResultImplementation requestResult = new RequestResultImplementation();
             requestResult.setResultNumStream(resultStream);
             return new EngineResponseImplementation(ResponseCode.SUCCESSFUL, requestResult);
+        } else {
+            ArrayList<Integer> resultList = new ArrayList<>();
+            factorialSumLoop(numStream.getIntegers(), resultList);
+            return new EngineResponseImplementation(ResponseCode.SUCCESSFUL, resultList);
         }
-		ArrayList<Integer> resultList = new ArrayList<>();
 
-		factorialSumLoop(numStream.getIntegers(), resultList);
-
-		return new EngineResponseImplementation(ResponseCode.SUCCESSFUL, resultList);
 	}
 
 	public void factorialSumLoop(List<Integer> inputList, ArrayList<Integer> resultList) {
@@ -95,7 +73,7 @@ public class ComputationImplementation implements ComputeEngineComputation {
 			//find the sum of the digits of the factorial
 			BigInteger sumDigits = new BigInteger("0");
             while (result.compareTo(new BigInteger("0")) != 0) {
-                sumDigits = sumDigits.add(result.divide(new BigInteger("10")));
+                sumDigits = sumDigits.add(result.mod(new BigInteger("10")));
                 result = result.divide(new BigInteger("10"));
             }
 			resultList.add(sumDigits);

--- a/src/ComputationImplementation.java
+++ b/src/ComputationImplementation.java
@@ -1,6 +1,8 @@
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
+import interfaces.BigIntegerNumStream;
 import interfaces.NumStream;
 
 public class ComputationImplementation implements ComputeEngineComputation {
@@ -9,6 +11,36 @@ public class ComputationImplementation implements ComputeEngineComputation {
 		if(numStream == null) {
 			throw new IllegalArgumentException("NumStream cannot be null");
 		}
+        if (numStream instanceof BigIntegerNumStream biNumStream){
+            ArrayList<BigInteger> resultList = new ArrayList<>();
+            factorialSumLoopForBigIntegers(biNumStream.getBigIntegers(), resultList);
+            NumStream resultStream = new BigIntegerNumStream() {
+
+                @Override
+                public List<Integer> getIntegers() {
+                    throw new UnsupportedOperationException("Unimplemented method 'getIntegers'");
+                }
+
+                @Override
+                public void setIntegerList(List<Integer> integerList) {
+                    throw new UnsupportedOperationException("Unimplemented method 'setIntegerList'");
+                }
+
+                @Override
+                public List<BigInteger> getBigIntegers() {
+                    return resultList;
+                }
+
+                @Override
+                public void setBigIntegerList(List<BigInteger> bigIntegerList) {
+                    throw new UnsupportedOperationException("Unimplemented method 'setBigIntegerList'");
+                }
+
+            };
+            RequestResultImplementation requestResult = new RequestResultImplementation();
+            requestResult.setResultNumStream(resultStream);
+            return new EngineResponseImplementation(ResponseCode.SUCCESSFUL, requestResult);
+        }
 		ArrayList<Integer> resultList = new ArrayList<>();
 
 		factorialSumLoop(numStream.getIntegers(), resultList);
@@ -39,6 +71,33 @@ public class ComputationImplementation implements ComputeEngineComputation {
 				result = result / 10;
 			}
 			//add to result list
+			resultList.add(sumDigits);
+		}
+	}
+
+    public void factorialSumLoopForBigIntegers(List<BigInteger> inputList, ArrayList<BigInteger> resultList) {
+		if(inputList == null || inputList.isEmpty()) {
+			throw new IllegalArgumentException("Input list cannot be null or empty");
+		}
+		if(resultList == null) {
+			throw new IllegalArgumentException("Output list cannot be null");
+		}
+
+		//finds the factorial of the input
+		for (BigInteger inputNum : inputList) {
+			if(inputNum.compareTo(new BigInteger("0")) < 0) {
+				throw new IllegalArgumentException("Cannot compute the factorial of " + inputNum);
+			}
+			BigInteger result = new BigInteger("1");
+			for (BigInteger interval = inputNum; interval.compareTo(new BigInteger("0")) > 0; interval = interval.subtract(new BigInteger("1"))) {
+                result = result.multiply(interval);
+			}
+			//find the sum of the digits of the factorial
+			BigInteger sumDigits = new BigInteger("0");
+            while (result.compareTo(new BigInteger("0")) != 0) {
+                sumDigits = sumDigits.add(result.divide(new BigInteger("10")));
+                result = result.divide(new BigInteger("10"));
+            }
 			resultList.add(sumDigits);
 		}
 	}

--- a/src/ComputeEngineImplementation.java
+++ b/src/ComputeEngineImplementation.java
@@ -1,102 +1,141 @@
-import datastoreapi.DataStoreAPI;
-import datastoreapi.OutputRequest;
-import interfaces.NumStream;
-
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
+import datastoreapi.DataStoreAPI;
+import datastoreapi.DataStoreAPI.BigIntegerListWrapper;
+import datastoreapi.DataStoreAPI.IntegerListWrapper;
+import datastoreapi.DataStoreAPI.ListWrapper;
+import datastoreapi.OutputRequest;
+import interfaces.BigIntegerNumStream;
+import interfaces.NumStream;
+
 public class ComputeEngineImplementation implements ComputeEngine {
-  DataStoreAPI dataStoreAPI;
-  ComputeEngineComputation computeEngineComputation;
-  ComputeRequestHandler computeRequestHandler;
+    DataStoreAPI dataStoreAPI;
+    ComputeEngineComputation computeEngineComputation;
+    ComputeRequestHandler computeRequestHandler;
 
-  public ComputeEngineImplementation(ComputeEngineComputation computeEngineComputation, ComputeRequestHandler computeRequestHandler, DataStoreAPI dataStoreAPI) {
-    this.computeEngineComputation = computeEngineComputation;
-    this.computeRequestHandler = computeRequestHandler;
-    this.dataStoreAPI = dataStoreAPI;
-  }
-
-  public ComputeEngineImplementation(ComputeEngineComputation computeEngineComputation, ComputeRequestHandler computeRequestHandler) {
-    this.computeEngineComputation = computeEngineComputation;
-    this.computeRequestHandler = computeRequestHandler;
-  }
-
-  public ComputeEngineImplementation(ComputeEngineComputation computeEngineComputation) {
-    this.computeEngineComputation = computeEngineComputation;
-  }
-
-  public ComputeEngineComputation getComputeEngineComputation() {
-    return computeEngineComputation;
-  }
-
-  public void setComputeEngineComputation(ComputeEngineComputation computeEngineComputation) {
-    this.computeEngineComputation = computeEngineComputation;
-  }
-
-  @Override
-  public EngineResponse submitRequest(UserRequest userRequest) {
-    return submitRequest(userRequest, false);
-  }
-
-  @Override
-  public EngineResponse submitRequest(UserRequest userRequest, boolean internalRequest) {
-    try {
-      return submitRequestHelper(userRequest, internalRequest);
-    } catch (Exception e) {
-      return new EngineResponseExceptionImplementation(e);
-    }
-  }
-  
-  public EngineResponse submitRequestHelper(UserRequest userRequest, boolean internalRequest) throws Exception {
-	if(userRequest == null) {
-		throw new IllegalArgumentException("UserRequest cannot be null");
-	}
-	EngineResponse engineResponse = sendStreamForFactorial(userRequest.getRequestStream());
-	NumStream resultStream = engineResponse.getRequestResult().getResultNumStream();
-
-	RequestResult requestResult = engineResponse.getRequestResult();
-
-	requestResult.setResultString(processResultString(userRequest, (ArrayList<Integer>) resultStream.getIntegers()));
-
-  if (internalRequest) {
-    dataStoreAPI.setOutputList(new ArrayList<>(List.of(requestResult.getResultString())));
-    UserRequestDestination requestDestination = userRequest.getUserRequestDestination();
-    if (requestDestination instanceof FileUserRequestDestination fileRequestDestination){
-        dataStoreAPI.writeOutput(new OutputRequest(fileRequestDestination.getFileName()));
-    }
-  }
-
-	return engineResponse;
-  }
-
-  @Override
-  public EngineResponse sendStreamForFactorial(NumStream numStream) {
-	if(numStream == null) {
-		throw new IllegalArgumentException("NumStream cannot be null");
-	}
-    return computeEngineComputation.doFactorial(numStream);
-  }
-
-  public String processResultString(UserRequest userRequest, ArrayList<Integer> resultList) {
-	if(userRequest == null){
-		throw new IllegalArgumentException("UserRequest cannot be null");
-	}
-    List<Integer> requestStream = userRequest.getRequestStream().getIntegers();
-    StringBuilder result = new StringBuilder();
-    int resultPosition = 0;
-
-    for (Integer requestInteger : requestStream) {
-      result.append(requestInteger);
-      result.append(userRequest.getResultDelimiter());
-      result.append(resultList.get(resultPosition));
-
-      if(requestStream.size() > resultPosition + 1) {
-        result.append(userRequest.getPairDelimiter());
-      }
-
-      resultPosition++;
+    public ComputeEngineImplementation(ComputeEngineComputation computeEngineComputation, ComputeRequestHandler computeRequestHandler, DataStoreAPI dataStoreAPI) {
+        this.computeEngineComputation = computeEngineComputation;
+        this.computeRequestHandler = computeRequestHandler;
+        this.dataStoreAPI = dataStoreAPI;
     }
 
-    return result.toString();
-  }
+    public ComputeEngineImplementation(ComputeEngineComputation computeEngineComputation, ComputeRequestHandler computeRequestHandler) {
+        this.computeEngineComputation = computeEngineComputation;
+        this.computeRequestHandler = computeRequestHandler;
+    }
+
+    public ComputeEngineImplementation(ComputeEngineComputation computeEngineComputation) {
+        this.computeEngineComputation = computeEngineComputation;
+    }
+
+    public ComputeEngineComputation getComputeEngineComputation() {
+        return computeEngineComputation;
+    }
+
+    public void setComputeEngineComputation(ComputeEngineComputation computeEngineComputation) {
+        this.computeEngineComputation = computeEngineComputation;
+    }
+
+    @Override
+    public EngineResponse submitRequest(UserRequest userRequest) {
+        return submitRequest(userRequest, false);
+    }
+
+    @Override
+    public EngineResponse submitRequest(UserRequest userRequest, boolean internalRequest) {
+        try {
+            return submitRequestHelper(userRequest, internalRequest);
+        } catch (Exception e) {
+            return new EngineResponseExceptionImplementation(e);
+        }
+    }
+
+    public EngineResponse submitRequestHelper(UserRequest userRequest, boolean internalRequest) throws Exception {
+        if(userRequest == null) {
+            throw new IllegalArgumentException("UserRequest cannot be null");
+        }
+        EngineResponse engineResponse = sendStreamForFactorial(userRequest.getRequestStream());
+        NumStream resultStream = engineResponse.getRequestResult().getResultNumStream();
+        RequestResult requestResult = engineResponse.getRequestResult();
+
+        if (resultStream instanceof BigIntegerNumStream biNumStream){
+            requestResult.setResultString(processResultStringForBigInteger(userRequest, biNumStream.getBigIntegers()));
+        } else {
+            requestResult.setResultString(processResultString(userRequest, resultStream.getIntegers()));
+        }
+
+        if (internalRequest) {
+            dataStoreAPI.setOutputList(new ArrayList<>(List.of(requestResult.getResultString())));
+            UserRequestDestination requestDestination = userRequest.getUserRequestDestination();
+            if (requestDestination instanceof FileUserRequestDestination fileRequestDestination){
+                dataStoreAPI.writeOutput(new OutputRequest(fileRequestDestination.getFileName()));
+            }
+        }
+
+        return engineResponse;
+    }
+
+    @Override
+    public EngineResponse sendStreamForFactorial(NumStream numStream) {
+        if(numStream == null) {
+            throw new IllegalArgumentException("NumStream cannot be null");
+        }
+        return computeEngineComputation.doFactorial(numStream);
+    }
+
+    
+
+    public String processResultStringForBigInteger(UserRequest userRequest, List<BigInteger> resultList) {
+        if(userRequest == null){
+            throw new IllegalArgumentException("UserRequest cannot be null");
+        }
+        NumStream requestNumStream = userRequest.getRequestStream();
+        if (!(requestNumStream instanceof BigIntegerNumStream biNumStream)){
+            throw new UnsupportedOperationException("BigIntegerNumStream required");
+        }
+        List<BigInteger> requestStream = biNumStream.getBigIntegers();
+        StringBuilder result = new StringBuilder();
+        int resultPosition = 0;
+        for (BigInteger requestInteger : requestStream) {
+            result.append(requestInteger);
+            result.append(userRequest.getResultDelimiter());
+            result.append(resultList.get(resultPosition));
+
+            if(requestStream.size() > resultPosition + 1) {
+                result.append(userRequest.getPairDelimiter());
+            }
+
+            resultPosition++;
+        }
+
+        return result.toString();
+
+    }
+
+    @Deprecated
+    public String processResultString(UserRequest userRequest, List<Integer> resultList) {
+        if(userRequest == null){
+            throw new IllegalArgumentException("UserRequest cannot be null");
+        }
+        List<Integer> requestStream = userRequest.getRequestStream().getIntegers();
+        StringBuilder result = new StringBuilder();
+        int resultPosition = 0;
+
+        for (Integer requestInteger : requestStream) {
+            result.append(requestInteger);
+            result.append(userRequest.getResultDelimiter());
+            result.append(resultList.get(resultPosition));
+
+            if(requestStream.size() > resultPosition + 1) {
+                result.append(userRequest.getPairDelimiter());
+            }
+
+            resultPosition++;
+        }
+
+        return result.toString();
+    }
+
 }

--- a/src/ComputeEngineImplementation.java
+++ b/src/ComputeEngineImplementation.java
@@ -114,7 +114,6 @@ public class ComputeEngineImplementation implements ComputeEngine {
 
     }
 
-    @Deprecated
     public String processResultString(UserRequest userRequest, List<Integer> resultList) {
         if(userRequest == null){
             throw new IllegalArgumentException("UserRequest cannot be null");

--- a/src/EngineResponseImplementation.java
+++ b/src/EngineResponseImplementation.java
@@ -19,6 +19,17 @@ public class EngineResponseImplementation implements EngineResponse {
 		this.requestResult = new RequestResultImplementation(requestResult);
 	}
 
+	public EngineResponseImplementation(ResponseCode responseCode, RequestResult requestResult) {
+		if(responseCode == null) {
+			throw new IllegalArgumentException("ResponseCode cannot be null");
+		}
+		if(requestResult == null) {
+			throw new IllegalArgumentException("Result list cannot be null");
+		}
+		this.responseCode = responseCode;
+		this.requestResult = requestResult;
+	}
+
 	@Override
 	public void setRequestResult(RequestResult result) {
 		if(result == null) {

--- a/src/NumStreamImplementation.java
+++ b/src/NumStreamImplementation.java
@@ -4,26 +4,26 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class NumStreamImplementation implements NumStream {
-  public List<Integer> integerList;
+    public List<Integer> integerList;
 
-  public NumStreamImplementation() {
-  }
+    public NumStreamImplementation() {
+    }
 
-  public NumStreamImplementation(List<Integer> integerList) {
-  	if(integerList == null) {
-		throw new IllegalArgumentException("Integer list cannot be null");
-	}
-   	this.integerList = integerList;
-  }
+    public NumStreamImplementation(List<Integer> integerList) {
+        if(integerList == null) {
+            throw new IllegalArgumentException("Integer list cannot be null");
+        }
+        this.integerList = integerList;
+    }
 
-  public List<Integer> getIntegers() {
-    	return integerList;
-  }
+    public List<Integer> getIntegers() {
+        return integerList;
+    }
 
-  public void setIntegerList(List<Integer> integerList) {
-	if(integerList == null) {
-		throw new IllegalArgumentException("Integer list cannot be null");
-	}
-    	this.integerList =  integerList;
-  }
+    public void setIntegerList(List<Integer> integerList) {
+        if(integerList == null) {
+            throw new IllegalArgumentException("Integer list cannot be null");
+        }
+        this.integerList =  integerList;
+    }
 }

--- a/src/RequestResultImplementation.java
+++ b/src/RequestResultImplementation.java
@@ -4,39 +4,39 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 
 public class RequestResultImplementation implements RequestResult {
-  NumStream result;
-  String resultString;
+    NumStream result;
+    String resultString;
 
-  public RequestResultImplementation() {
-  }
+    public RequestResultImplementation() {
+    }
 
-  public RequestResultImplementation(ArrayList<Integer> result) {
-	if(result == null) {
-		throw new IllegalArgumentException("Result list cannot be null");
-	}
-    	this.result = new NumStreamImplementation(result);
-  }
+    public RequestResultImplementation(ArrayList<Integer> result) {
+        if(result == null) {
+            throw new IllegalArgumentException("Result list cannot be null");
+        }
+        this.result = new NumStreamImplementation(result);
+    }
 
-  public NumStream getResultNumStream() {
-    	return result;
-  }
+    public NumStream getResultNumStream() {
+        return result;
+    }
 
-  @Override
-  public String getResultString() {
-    	return resultString;
-  }
+    @Override
+    public String getResultString() {
+        return resultString;
+    }
 
-  public void setResultNumStream(NumStream resultNumStream) {
-	if(resultNumStream == null) {
-		throw new IllegalArgumentException("NumStream cannot be null");
-	}
-    this.result = resultNumStream;
-  }
+    public void setResultNumStream(NumStream resultNumStream) {
+        if(resultNumStream == null) {
+            throw new IllegalArgumentException("NumStream cannot be null");
+        }
+        this.result = resultNumStream;
+    }
 
-  public void setResultString(String resultString) {
-	if(resultString == null) {
-		throw new IllegalArgumentException("Result cannot be null");
-	}
-    	this.resultString = resultString;
-  }
+    public void setResultString(String resultString) {
+        if(resultString == null) {
+            throw new IllegalArgumentException("Result cannot be null");
+        }
+        this.resultString = resultString;
+    }
 }

--- a/src/UserRequest.java
+++ b/src/UserRequest.java
@@ -4,8 +4,8 @@ public class UserRequest {
 	private NumStream requestStream;
 	private UserRequestSource userRequestSource;
 	private UserRequestDestination userRequestDestination;
-	private char resultDelimiter;
-	private char pairDelimiter;
+	private char resultDelimiter = ':';
+	private char pairDelimiter = ',';
 
 	public UserRequest(NumStream requestStream, UserRequestSource userRequestSource, UserRequestDestination userRequestDestination, char resultDelimiter,
 			char pairDelimiter) {

--- a/src/datastoreapi/DataStoreAPI.java
+++ b/src/datastoreapi/DataStoreAPI.java
@@ -107,7 +107,7 @@ public class DataStoreAPI {
         }
         public List<BigInteger> getBigIntegerList(){
             return list;
-        };
+        }
     }
 
     public class IntegerListWrapper implements ListWrapper{
@@ -117,7 +117,7 @@ public class DataStoreAPI {
         }
         public List<Integer> getIntegerList(){
             return list;
-        };
+        }
     }
 
 	public ListWrapper readInputMulti(InputRequest inputRequest) {

--- a/src/datastoreapi/DataStoreAPI.java
+++ b/src/datastoreapi/DataStoreAPI.java
@@ -1,12 +1,13 @@
 package datastoreapi;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Scanner;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
 
 public class DataStoreAPI {
 
@@ -76,6 +77,7 @@ public class DataStoreAPI {
 	}
 
 	// input response method
+    @Deprecated
 	public List<Integer> readInput(InputRequest inputRequest) {
 		if(inputRequest == null) {
 			throw new IllegalArgumentException("InputRequest cannot be null");
@@ -94,7 +96,66 @@ public class DataStoreAPI {
 		return inputList;
 	}
 
+    public interface ListWrapper {
+        
+    }
+
+    public class BigIntegerListWrapper implements ListWrapper{
+        private List<BigInteger> list;
+        public BigIntegerListWrapper(List<BigInteger> list) {
+            this.list=list;
+        }
+        public List<BigInteger> getBigIntegerList(){
+            return list;
+        };
+    }
+
+    public class IntegerListWrapper implements ListWrapper{
+        private List<Integer> list;
+        public IntegerListWrapper(List<Integer> list) {
+            this.list=list;
+        }
+        public List<Integer> getIntegerList(){
+            return list;
+        };
+    }
+
+	public ListWrapper readInputMulti(InputRequest inputRequest) {
+		if(inputRequest == null) {
+			throw new IllegalArgumentException("InputRequest cannot be null");
+		}
+        List<Integer> tempList = new ArrayList<>();
+        boolean useBigIntegers = false;
+		try {
+			FileReader f = new FileReader(inputRequest.getFile()); 
+			Scanner in = new Scanner(f);
+			while (in.hasNextLine()) {
+				String[] inputs = in.nextLine().split(",");
+                for (String string : inputs) {
+                    int input = Integer.valueOf(string.strip());
+                    if (input > 12 && !useBigIntegers){
+                        useBigIntegers = true;
+                    }
+                    tempList.add(input);
+                }
+			}
+			in.close();
+		} catch (FileNotFoundException e) {
+			e.printStackTrace();
+		}
+        if (useBigIntegers){
+            List<BigInteger> finalList = new ArrayList<BigInteger>();
+            for (Integer integer : tempList) {
+                finalList.add(new BigInteger(String.valueOf(integer)));
+            }
+            return new BigIntegerListWrapper(finalList);
+        } else {
+            return new IntegerListWrapper(tempList);
+        }
+	}
+
 	// output response method
+    @Deprecated
 	public List<String> writeOutput(OutputRequest outputRequest) {
 		if(outputRequest == null) {
 			throw new IllegalArgumentException("OutputRequest cannot be null");

--- a/src/datastoreapi/DataStoreAPI.java
+++ b/src/datastoreapi/DataStoreAPI.java
@@ -155,7 +155,6 @@ public class DataStoreAPI {
 	}
 
 	// output response method
-    @Deprecated
 	public List<String> writeOutput(OutputRequest outputRequest) {
 		if(outputRequest == null) {
 			throw new IllegalArgumentException("OutputRequest cannot be null");

--- a/src/interfaces/BigIntegerNumStream.java
+++ b/src/interfaces/BigIntegerNumStream.java
@@ -1,0 +1,10 @@
+package interfaces;
+
+import java.math.BigInteger;
+import java.util.List;
+
+public interface BigIntegerNumStream extends NumStream {
+    List<BigInteger> getBigIntegers();
+
+    void setBigIntegerList(List<BigInteger> bigIntegerList);
+}


### PR DESCRIPTION
Adds support for `BigIntegers`, program should be able to handle inputs greater than 12 now. Updates both grpc server and standalone commandline. `readinput` method from `DataStorageAPI` has been depreciated in favor of `readInputMulti`, which returns types of `ListWrapper`: `IntegerListWrapper` and `BigIntegerListWrapper`.